### PR TITLE
feat: Copilot Chatの統合とエディタUIの設定改善 # Please enter the commit message f…

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,6 +1,7 @@
 {
   "AstroNvim": { "branch": "main", "commit": "56e5d8c4a73237c100a8271155c24760ec58d7f7" },
   "Comment.nvim": { "branch": "master", "commit": "e30b7f2008e52442154b66f7c519bfd2f1e32acb" },
+  "CopilotChat.nvim": { "branch": "main", "commit": "a89f5f1162b04a0962e5f4c3cdf248a81e7e53cb" },
   "LuaSnip": { "branch": "master", "commit": "03c8e67eb7293c404845b3982db895d59c0d1538" },
   "SchemaStore.nvim": { "branch": "main", "commit": "b265e7b68308c9b68581d57c3f79419ce5e8dca2" },
   "aerial.nvim": { "branch": "master", "commit": "1160fb7a15a34b03b7381d95d45560712b5f19d0" },

--- a/lua/plugins/astrocore.lua
+++ b/lua/plugins/astrocore.lua
@@ -10,7 +10,7 @@ return {
   opts = {
     -- Configure core features of AstroNvim
     features = {
-      large_buf = { size = 1024 * 500, lines = 10000 }, -- set global limits for large files for disabling features like treesitter
+      large_buf = { size = 1024 * 500, lines = 10000, notify = false }, -- set global limits for large files for disabling features like treesitter
       autopairs = true, -- enable autopairs at start
       cmp = true, -- enable completion at start
       diagnostics_mode = 3, -- diagnostic mode on start (0 = off, 1 = no signs/virtual text, 2 = no virtual text, 3 = on)
@@ -25,11 +25,11 @@ return {
     -- vim options can be configured here
     options = {
       opt = { -- vim.opt.<key>
-        relativenumber = true, -- sets vim.opt.relativenumber
+        relativenumber = false, -- sets vim.opt.relativenumber
         number = true, -- sets vim.opt.number
         spell = false, -- sets vim.opt.spell
         signcolumn = "auto", -- sets vim.opt.signcolumn to auto
-        wrap = false, -- sets vim.opt.wrap
+        wrap = true, -- sets vim.opt.wrap
       },
       g = { -- vim.g.<key>
         -- configure global vim variables (vim.g)

--- a/lua/plugins/copilot-chat.lua
+++ b/lua/plugins/copilot-chat.lua
@@ -1,0 +1,130 @@
+---@module CopilotChat.nvim
+---@description Neovim用のCopilot Chatインテグレーションを提供するプラグイン
+---@author CopilotC-Nvim
+
+return {
+  {
+    "CopilotC-Nvim/CopilotChat.nvim",
+    dependencies = {
+      { "github/copilot.vim" }, -- または zbirenbaum/copilot.lua を使用可能
+      { "nvim-lua/plenary.nvim", branch = "master" }, -- curl、ログ、非同期関数のために必要
+    },
+    build = "make tiktoken", -- MacOSまたはLinuxのみ
+    config = function()
+      local select = require "CopilotChat.select"
+      require("CopilotChat").setup {
+        -- デバッグモードを有効にする
+        debug = true,
+        -- プロキシ設定（nilの場合はプロキシを使用しない）
+        proxy = nil,
+        -- 安全でない接続を許可するかどうか
+        allow_insecure = false,
+        -- 使用するAIモデル
+        model = "claude-3.7-sonnet",
+        -- 生成テキストの多様性（0.0-1.0、低いほど一貫性が高い）
+        temperature = 0.1,
+        -- 定義済みプロンプトのセット
+        prompts = {
+          -- コード説明用プロンプト
+          Explain = {
+            prompt = "/COPILOT_EXPLAIN 選択したコードの説明を段落をつけて書いてください。",
+            system_prompt = "あなたは優れたプログラマーであり、ドキュメント作成の専門家です。言語は日本語を使います。",
+            context = { "buffer: 'current'" },
+          },
+          -- バグ修正用プロンプト
+          Fix = {
+            prompt = "/COPILOT_FIX このコードには問題があります。バグを修正したコードに書き換えてください。",
+            system_prompt = "あなたは優れたプログラマーです。言語は日本語を使います。",
+            context = { "buffer: 'current'" },
+          },
+          -- コード最適化用プロンプト
+          Optimize = {
+            prompt = "/COPILOT_OPTIMIZE このコードを最適化し、パフォーマンスと可読性を向上させてください。",
+            system_prompt = "あなたは優れたプログラマーであり、パフォーマンスチューニングの専門家です。言語は日本語を使います。",
+            context = { "buffer: 'current'" },
+          },
+          -- ドキュメント生成用プロンプト
+          Docs = {
+            prompt = "/COPILOT_DOCS このコードのドキュメントを書いてください。ドキュメントをコメントとして追加した元のコードを含むコードブロックで回答してください。使用するプログラミング言語に最も適したドキュメントスタイルを使用してください（例：JavaScriptのJSDoc、Pythonのdocstringsなど）",
+            system_prompt = "あなたは優れたプログラマーであり、ドキュメント作成の専門家です。言語は日本語を使います。",
+            context = { "buffer: 'current'" },
+          },
+          -- テスト生成用プロンプト
+          Tests = {
+            prompt = "/COPILOT_TESTS 選択したコードの詳細な単体テスト関数を書いてください。",
+            system_prompt = "あなたは優れたプログラマーであり、テスト駆動開発の専門家です。言語は日本語を使います。",
+            context = { "buffer: 'current'" },
+          },
+          -- 診断修正用プロンプト
+          FixDiagnostic = {
+            prompt = "/COPILOT_FIXDIAGNOSTIC ファイル内の次のような診断上の問題を解決してください：",
+            selection = select.diagnostics or select.selection or function() return {} end,
+          },
+          -- コミットメッセージ生成用プロンプト
+          Commit = {
+            prompt = "/COPILOT_COMMIT この変更をコミットしてください。",
+            selection = select.gitdiff or select.selection or function() return {} end,
+          },
+          -- ステージング済み変更のコミット用プロンプト
+          CommitStaged = {
+            prompt = "変更のコミットメッセージをcommitizenの規約に従って日本語で書いてください。タイトルは最大50文字、メッセージは72文字で折り返してください。メッセージ全体をgitcommit言語のコードブロックで囲んでください。",
+            context = { "git:staged" },
+          },
+          -- コードレビュー用プロンプト
+          Review = {
+            prompt = "/COPILOT_REVIEW 選択したコードをレビューしてください。",
+            selection = select.selection or function() return {} end,
+          },
+        },
+        -- ウィンドウ設定
+        window = {
+          -- レイアウト種別（vertical/horizontal/floating）
+          layout = "vertical",
+          -- ウィンドウの幅（相対サイズ）
+          width = 0.3,
+          -- ウィンドウの高さ（相対サイズ）
+          height = 0.3,
+          -- 配置の基準
+          relative = "editor",
+          -- ウィンドウの枠線スタイル
+          border = "single",
+          -- 上端からの位置
+          row = 0,
+          -- 左端からの位置
+          col = 0,
+          -- ウィンドウのタイトル
+          title = "Copilot Chat",
+          -- ウィンドウのフッター
+          footer = nil,
+          -- Z軸の重なり順（大きいほど前面）
+          zindex = 1,
+        },
+        -- キーマッピング設定
+        mapping = {
+          yank_diff = {
+            -- 差分をヤンクするための通常モードキー
+            normal = "cy",
+            -- ヤンク時に使用するレジスタ
+            register = '"', -- デフォルトレジスタ
+          },
+        },
+      }
+
+      ---@function CopilotChatBuffer
+      ---@description 現在のバッファについてCopilotに質問するためのクイックチャット機能を提供する
+      ---@return nil
+      function CopilotChatBuffer()
+        local input = vim.fn.input "Quick Chat: "
+        if input ~= "" then require("CopilotChat").ask(input, { selection = require("CopilotChat.select").buffer }) end
+      end
+
+      -- キーマップの設定
+      -- クイックチャットを開始
+      vim.api.nvim_set_keymap("n", "<leader>gpq", "<cmd>lua CopilotChatBuffer()<cr>", { noremap = true, silent = true })
+      -- プロンプト一覧を表示
+      vim.api.nvim_set_keymap("n", "<leader>gpp", "<cmd>CopilotChatPrompts<cr>", { noremap = true, silent = true })
+      -- Copilot Chatの表示/非表示を切り替え
+      vim.api.nvim_set_keymap("n", "<leader>gpt", "<cmd>CopilotChatToggle<cr>", { noremap = true, silent = true })
+    end,
+  },
+}


### PR DESCRIPTION
…or your changes. Lines starting # with '#' will be ignored, and an empty message aborts the commit. # # On branch add_copilot_chat # Changes to be

committed: # modified:  lazy-lock.json # modified:  lua/plugins/astrocore.lua # new file:  lua/plugins/copilot-chat.lua # • GitHub Copilot Chat NvimをAstroNvimに統合
  - 日本語対応のプロンプト設定 - キーマッピングの追加（<leader>gpq/p/t） - Claude 3.7 Sonnetモデルを使用 • エディタUI設定の調整 - 相対行番号を無効化 - テキストラップを有効化 - 大きなバッファのサイズ超過通知を無効化